### PR TITLE
Additional typescript-eslint rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "utilities"
   ],
   "devDependencies": {
-    "eslint": "6.4.0",
+    "eslint": "6.5.1",
     "eslint-config-vartanovs": "0.1.1",
-    "lerna": "3.16.4",
-    "typescript": "3.6.3"
+    "lerna": "3.18.3",
+    "typescript": "3.6.4"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/eslint-config-vartanovs/index.js
+++ b/packages/eslint-config-vartanovs/index.js
@@ -15,10 +15,15 @@ module.exports = {
   },
   plugins: ['@typescript-eslint'],
   rules: {
+    '@typescript-eslint/array-type': 'error',
     '@typescript-eslint/await-thenable': 'error',
+    '@typescript-eslint/ban-ts-ignore': 'error',
+    '@typescript-eslint/brace-style': ['error', '1tbs', { allowSingleLine: true }],
     '@typescript-eslint/camelcase': ['error', { properties: 'never' }],
     '@typescript-eslint/class-name-casing': 'error',
-    '@typescript-eslint/ban-ts-ignore': 'error',
+    '@typescript-eslint/consistent-type-assertions': 'error',
+    '@typescript-eslint/cconsistent-type-definitions': ['error', 'interface'],
+    '@typescript-eslint/func-call-spacing': ['error', 'never'],
     '@typescript-eslint/indent': ['error', 2, {
       ArrayExpression: 1,
       CallExpression: { arguments: 1 },
@@ -33,7 +38,10 @@ module.exports = {
       VariableDeclarator: 1,
       ignoreComments: false
     }],
+    '@typescript-eslint/member-delimiter-style)': 'error',
+    '@typescript-eslint/no-array-constructor': 'error',
     '@typescript-eslint/no-explicit-any': 'error',
+    '@typescript-eslint/no-extra-parens': 'error',
     '@typescript-eslint/no-unused-vars': 'error',
     '@typescript-eslint/quotes': ['error', 'single'],
     '@typescript-eslint/require-await': 'error',

--- a/packages/eslint-config-vartanovs/package.json
+++ b/packages/eslint-config-vartanovs/package.json
@@ -12,10 +12,10 @@
     "eslint"
   ],
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "2.3.1",
-    "@typescript-eslint/parser": "2.3.1"
+    "@typescript-eslint/eslint-plugin": "2.5.0",
+    "@typescript-eslint/parser": "2.5.0"
   },
   "devDependencies": {
-    "eslint": "6.4.0"
+    "eslint": "6.5.1"
   }
 }


### PR DESCRIPTION
Rules evaluated thru '@typescript-eslint/no-extra-parens'